### PR TITLE
Quick fix for building types

### DIFF
--- a/brails/imputers/knn_imputer/knn_imputer.py
+++ b/brails/imputers/knn_imputer/knn_imputer.py
@@ -432,8 +432,8 @@ class KnnImputer(Imputation):
         self, bldg_properties_encoded, bldg_geometries_df, nbldg_per_cluster=500, seed=0
     ):
         nbldg = bldg_properties_encoded.shape[0]
-        n_cluster = int(nbldg / nbldg_per_cluster)  # 500 bldgs per cluster
-        kmeans = KMeans(n_clusters=n_cluster, random_state=seed, n_init="auto").fit(
+        n_cluster = int(np.ceil(nbldg / nbldg_per_cluster))  # 500 bldgs per cluster
+        kmeans = KMeans(n_clusters=int(n_cluster), random_state=seed, n_init="auto").fit(
             bldg_geometries_df[["Lat", "Lon"]]
         )
         cluster_ids = kmeans.predict(bldg_geometries_df[["Lat", "Lon"]])

--- a/brails/inferers/hazus_hurricane_inferer/BuildingClassRulesets.py
+++ b/brails/inferers/hazus_hurricane_inferer/BuildingClassRulesets.py
@@ -69,14 +69,14 @@ def building_class(BIM, hazard):
 
     # just for brevity
     def quick_check_keys(needed_features):
-        return is_ready_to_infer(available_features=BIM.keys(), needed_features = needed_features,inferred_feature= "BuildingTag")
+        return is_ready_to_infer(available_features=BIM.keys(), needed_features = needed_features,inferred_feature= "BuildingClass")
 
 
     if hazard == 'wind':
 
         quick_check_keys(['BuildingMaterial'])
-        if BIM['BuildingMaterial'] == 'Wood':
-
+        if BIM['BuildingMaterial'].startswith('W'):
+            #Wood
             quick_check_keys(['OccupancyClass','RoofShape'])
             if ((BIM['OccupancyClass'] == 'RES1') or
                 ((BIM['RoofShape'] != 'flt') and (BIM['OccupancyClass'] == 'RES1'))):
@@ -93,8 +93,8 @@ def building_class(BIM, hazard):
                 # OccupancyClass = RES3, RES5, RES6, or COM8
                 # Wood Multi-Unit Hotel (WMUH1, WMUH2, or WMUH3)
                 bldg_class = 'WMUH'
-        elif BIM['BuildingMaterial'] == 'Steel':
-
+        elif BIM['BuildingMaterial'].startswith('S'):
+            #Steel
             quick_check_keys(['OccupancyClass','DesignLevel'])
             if ((BIM['DesignLevel'] == 'E') and
                 (BIM['OccupancyClass'] in ['RES3A', 'RES3B', 'RES3C', 'RES3D',
@@ -116,8 +116,8 @@ def building_class(BIM, hazard):
                 bldg_class = 'SPMB'
             else:
                 bldg_class = 'SECB'
-        elif BIM['BuildingMaterial'] == 'Concrete':
-
+        elif BIM['BuildingMaterial'].startswith('C'):
+            #Concrete
             quick_check_keys(['OccupancyClass','DesignLevel'])
             if ((BIM['DesignLevel'] == 'E') and
                 (BIM['OccupancyClass'] in ['RES3A', 'RES3B', 'RES3C', 'RES3D',
@@ -133,9 +133,13 @@ def building_class(BIM, hazard):
                 bldg_class = 'CECB'
             else:
                 bldg_class = 'CECB'
-        elif BIM['BuildingMaterial'] == 'Masonry':
 
-            quick_check_keys(['OccupancyClass','NumberOfStories'])
+        elif BIM['BuildingMaterial'] == 'Manufactured':
+            bldg_class = 'MH'
+
+        elif BIM['BuildingMaterial'].startswith('M'):
+            #Masonry
+            quick_check_keys(['OccupancyClass','NumberOfStories','DesignLevel'])
             if BIM['OccupancyClass'] == 'RES1':
                 # BuildingType = 3004
                 # OccupancyClass = RES1
@@ -176,8 +180,6 @@ def building_class(BIM, hazard):
             #    # Masonry Multi-Unit Hotel/Motel Non-Engineered
             #    # (MMUH1NE, MMUH2NE, or MMUH3NE)
             #    return 'MMUHNE'
-        elif BIM['BuildingMaterial'] == 'Manufactured':
-            bldg_class = 'MH'
 
         else:
             bldg_class = 'WMUH'

--- a/brails/inferers/hazus_hurricane_inferer/WindCERBRulesets.py
+++ b/brails/inferers/hazus_hurricane_inferer/WindCERBRulesets.py
@@ -44,6 +44,7 @@
 # Tracy Kijewski-Correa
 
 import random
+from brails.inferers.hazus_hurricane_inferer.WindMetaVarRulesets import is_ready_to_infer
 
 def CERB_config(BIM):
     """
@@ -61,55 +62,79 @@ def CERB_config(BIM):
         class.
     """
 
-    year = BIM['YearBuilt'] # just for the sake of brevity
+    available_features = BIM.keys()
 
-    # Roof cover
-    if BIM['RoofShape'] in ['gab', 'hip']:
-        roof_cover = 'bur'
-        # Warning: HAZUS does not have N/A option for CECB, so here we use bur
-    else:
-        if year >= 1975:
-            roof_cover = 'spm'
-        else:
-            # year < 1975
+    if "RoofCover" in BIM:
+        roof_cover = BIM["RoofCover"]
+
+    elif is_ready_to_infer(available_features=available_features, needed_features = ["YearBuilt","RoofShape"], inferred_feature= "RoofCover"):
+
+        # Roof cover
+        if BIM['RoofShape'] in ['gab', 'hip']:
             roof_cover = 'bur'
-
-    # shutters
-    if year >= 2000:
-        shutters = BIM['WindBorneDebris']
-    # BOCA 1996 and earlier:
-    # Shutters were not required by code until the 2000 IBC. Before 2000, the
-    # percentage of commercial buildings that have shutters is assumed to be
-    # 46%. This value is based on a study on preparedness of small businesses
-    # for hurricane disasters, which says that in Sarasota County, 46% of
-    # business owners had taken action to wind-proof or flood-proof their
-    # facilities. In addition to that, 46% of business owners reported boarding
-    # up their businesses before Hurricane Katrina. In addition, compliance
-    # rates based on the Homeowners Survey data hover between 43 and 50 percent.
-    else:
-        if BIM['WindBorneDebris']:
-            shutters = random.random() < 0.45
+            # Warning: HAZUS does not have N/A option for CECB, so here we use bur
         else:
-            shutters = False
+            if BIM['YearBuilt'] >= 1975:
+                roof_cover = 'spm'
+            else:
+                # year < 1975
+                roof_cover = 'bur'
 
-    # Wind Debris (widd in HAZUS)
-    # HAZUS A: Res/Comm, B: Varies by direction, C: Residential, D: None
-    WIDD = 'C' # residential (default)
-    if BIM['OccupancyClass'] in ['RES1', 'RES2', 'RES3A', 'RES3B', 'RES3C',
-                                  'RES3D']:
-        WIDD = 'C' # residential
-    elif BIM['OccupancyClass'] == 'AGR1':
-        WIDD = 'D' # None
-    else:
-        WIDD = 'A' # Res/Comm
 
-    # Window area ratio
-    if BIM['WindowArea'] < 0.33:
-        WWR = 'low'
-    elif BIM['WindowArea'] < 0.5:
-        WWR = 'med'
-    else:
-        WWR = 'hig'
+
+    if "Shutters" in BIM:
+        roof_cover = BIM["Shutters"]
+
+    elif is_ready_to_infer(available_features=available_features, needed_features = ["YearBuilt","WindBorneDebris"], inferred_feature= "Shutters"):
+
+        # shutters
+        if BIM['YearBuilt'] >= 2000:
+            shutters = BIM['WindBorneDebris']
+        # BOCA 1996 and earlier:
+        # Shutters were not required by code until the 2000 IBC. Before 2000, the
+        # percentage of commercial buildings that have shutters is assumed to be
+        # 46%. This value is based on a study on preparedness of small businesses
+        # for hurricane disasters, which says that in Sarasota County, 46% of
+        # business owners had taken action to wind-proof or flood-proof their
+        # facilities. In addition to that, 46% of business owners reported boarding
+        # up their businesses before Hurricane Katrina. In addition, compliance
+        # rates based on the Homeowners Survey data hover between 43 and 50 percent.
+        else:
+            if BIM['WindBorneDebris']:
+                shutters = random.random() < 0.45
+            else:
+                shutters = False
+
+
+    if "WindDebrisClass" in BIM:
+        WIDD = BIM["WindDebrisClass"]
+
+    elif is_ready_to_infer(available_features=available_features, needed_features = ["OccupancyClass"], inferred_feature= "WindDebrisClass"):       
+        # Wind Debris (widd in HAZUS)
+        # HAZUS A: Res/Comm, B: Varies by direction, C: Residential, D: None
+        WIDD = 'C' # residential (default)
+        if BIM['OccupancyClass'] in ['RES1', 'RES2', 'RES3A', 'RES3B', 'RES3C', 'RES3D']:
+            WIDD = 'C' # residential
+        elif BIM['OccupancyClass'] == 'AGR1':
+            WIDD = 'D' # None
+        else:
+            WIDD = 'A' # Res/Comm
+
+
+    if "WindowAreaRatio" in BIM:
+        WWR = BIM["WindowAreaRatio"]
+
+    elif is_ready_to_infer(available_features=available_features, needed_features = ["WindowArea"], inferred_feature= "WindowAreaRatio"):       
+
+        # Window area ratio
+        if BIM['WindowArea'] < 0.33:
+            WWR = 'low'
+        elif BIM['WindowArea'] < 0.5:
+            WWR = 'med'
+        else:
+            WWR = 'hig'
+
+    is_ready_to_infer(available_features=available_features, needed_features = ["NumberOfStories"], inferred_feature= "BuildingTag for C.ERB")
 
     if BIM['NumberOfStories'] <= 2:
         bldg_tag = 'C.ERB.L'

--- a/brails/inferers/hazus_hurricane_inferer/WindEFRulesets.py
+++ b/brails/inferers/hazus_hurricane_inferer/WindEFRulesets.py
@@ -151,6 +151,7 @@ def HUEFSS_config(BIM):
         class.
     """
 
+    available_features = BIM.keys()
 
     if "RoofCover" in BIM:
         roof_cover = BIM["RoofCover"]
@@ -243,6 +244,7 @@ def HUEFH_config(BIM):
         class.
     """
 
+    available_features = BIM.keys()
     if "RoofCover" in BIM:
         roof_cover = BIM["RoofCover"]
 
@@ -325,6 +327,7 @@ def HUEFS_config(BIM):
         class.
     """
 
+    available_features = BIM.keys()
     if "RoofCover" in BIM:
         roof_cover = BIM["RoofCover"]
 

--- a/brails/inferers/hazus_hurricane_inferer/WindEFRulesets.py
+++ b/brails/inferers/hazus_hurricane_inferer/WindEFRulesets.py
@@ -45,7 +45,7 @@
 
 import random
 import datetime
-
+from brails.inferers.hazus_hurricane_inferer.WindMetaVarRulesets import is_ready_to_infer
 
 def HUEFFS_config(BIM):
     """
@@ -63,35 +63,53 @@ def HUEFFS_config(BIM):
         class.
     """
 
-    year = BIM['YearBuilt']  # just for the sake of brevity
+    if "RoofCover" in BIM:
+        roof_cover = BIM["RoofCover"]
 
-    # Roof cover
-    if year >= 1975:
-        roof_cover = 'spm'
-    else:
-        # year < 1975
-        roof_cover = 'bur'
-
-    # Wind debris
-    WIDD = 'A'
-
-    # Roof deck age
-    if year >= (datetime.datetime.now().year - 50):
-        DQ = 'god' # new or average
-    else:
-        DQ = 'por' # old
-
-    # Metal-RDA
-    if year > 2000:
-        if BIM['DesignWindSpeed'] <= 142:
-            MRDA = 'std'  # standard
+    elif is_ready_to_infer(available_features=available_features, needed_features = ["YearBuilt"], inferred_feature= "RoofCover"):
+        # Roof cover
+        if BIM['YearBuilt'] >= 1975:
+            roof_cover = 'spm'
         else:
-            MRDA = 'sup'  # superior
-    else:
-        MRDA = 'std'  # standard
+            # year < 1975
+            roof_cover = 'bur'
 
-    # Shutters
-    shutters = int(BIM['WBD'])
+    if "WindDebrisClass" in BIM:
+        WIDD = BIM["WindDebrisClass"]
+
+    else:
+        # Wind debris
+        WIDD = 'A'
+
+    if "RoofDeckAge" in BIM:
+        DQ = BIM["RoofDeckAge"]
+
+    elif is_ready_to_infer(available_features=available_features, needed_features = ["YearBuilt"], inferred_feature= "RoofDeckAge"):
+        # Roof deck age
+        if BIM['YearBuilt'] >= (datetime.datetime.now().year - 50):
+            DQ = 'god' # new or average
+        else:
+            DQ = 'por' # old
+
+    if "RoofDeckAttachmentM" in BIM:
+        MRDA = BIM["RoofDeckAttachmentM"]
+
+    elif is_ready_to_infer(available_features=available_features, needed_features = ["YearBuilt","DesignWindSpeed"], inferred_feature= "RoofDeckAttachmentM"):
+        # Metal-RDA
+        if BIM['YearBuilt'] > 2000:
+            if BIM['DesignWindSpeed'] <= 142:
+                MRDA = 'std'  # standard
+            else:
+                MRDA = 'sup'  # superior
+        else:
+            MRDA = 'std'  # standard
+
+    if "Shutters" in BIM:
+        shutters = BIM["Shutters"]
+
+    elif is_ready_to_infer(available_features=available_features, needed_features = ["WBD"], inferred_feature= "Shutters"):
+        # Shutters
+        shutters = int(BIM['WBD'])
 
     essential_features = dict(
         BuildingTag = 'HUEF.FS', 
@@ -104,7 +122,6 @@ def HUEFFS_config(BIM):
         )
 
     BIM.update(essential_features)
-
 
     # bldg_tag = 'HUEF.FS'
     # bldg_config = f"{bldg_tag}." \
@@ -133,35 +150,55 @@ def HUEFSS_config(BIM):
         class.
     """
 
-    year = BIM['YearBuilt']  # just for the sake of brevity
 
-    # Roof cover
-    if year >= 1975:
-        roof_cover = 'spm'
-    else:
-        # year < 1975
-        roof_cover = 'bur'
+    if "RoofCover" in BIM:
+        roof_cover = BIM["RoofCover"]
 
-    # Wind debris
-    WIDD = 'A'
-
-    # Roof deck age
-    if year >= (datetime.datetime.now().year - 50):
-        DQ = 'god' # new or average
-    else:
-        DQ = 'por' # old
-
-    # Metal-RDA
-    if year > 2000:
-        if BIM['DesignWindSpeed'] <= 142:
-            MRDA = 'std'  # standard
+    elif is_ready_to_infer(available_features=available_features, needed_features = ["YearBuilt"], inferred_feature= "RoofCover"):
+        # Roof cover
+        if BIM['YearBuilt'] >= 1975:
+            roof_cover = 'spm'
         else:
-            MRDA = 'sup'  # superior
-    else:
-        MRDA = 'std'  # standard
+            # year < 1975
+            roof_cover = 'bur'
 
-    # Shutters
-    shutters = BIM['WindBorneDebris']
+    if "WindDebrisClass" in BIM:
+        WIDD = BIM["WindDebrisClass"]
+    else:
+        WIDD = 'A'
+
+
+    if "RoofDeckAge" in BIM:
+        DQ = BIM["RoofDeckAge"]
+
+    elif is_ready_to_infer(available_features=available_features, needed_features = ["YearBuilt"], inferred_feature= "RoofDeckAge"):
+        # Roof deck age
+        if BIM['YearBuilt'] >= (datetime.datetime.now().year - 50):
+            DQ = 'god' # new or average
+        else:
+            DQ = 'por' # old
+
+
+
+    if "RoofDeckAttachmentM" in BIM:
+        MRDA = BIM["RoofDeckAttachmentM"]
+
+    elif is_ready_to_infer(available_features=available_features, needed_features = ["YearBuilt","DesignWindSpeed"], inferred_feature= "RoofDeckAttachmentM"):
+        # Metal-RDA
+        if BIM['YearBuilt'] > 2000:
+            if BIM['DesignWindSpeed'] <= 142:
+                MRDA = 'std'  # standard
+            else:
+                MRDA = 'sup'  # superior
+        else:
+            MRDA = 'std'  # standard
+
+    if "Shutters" in BIM:
+        shutters = BIM["Shutters"]
+
+    elif is_ready_to_infer(available_features=available_features, needed_features = ["WindBorneDebris"], inferred_feature= "Shutters"):
+        # Shutters
+        shutters = BIM['WindBorneDebris']
 
 
     essential_features = dict(
@@ -205,38 +242,51 @@ def HUEFH_config(BIM):
         class.
     """
 
-    year = BIM['YearBuilt']  # just for the sake of brevity
+    if "RoofCover" in BIM:
+        roof_cover = BIM["RoofCover"]
 
-    # Roof cover
-    if year >= 1975:
-        roof_cover = 'spm'
-    else:
-        # year < 1975
-        roof_cover = 'bur'
-
-    # Wind debris
-    WIDD = 'A'
-
-    # Shutters
-    shutters = BIM['WindBorneDebris']
-
-    # Metal-RDA
-    if year > 2000:
-        if BIM['DesignWindSpeed'] <= 142:
-            MRDA = 'std'  # standard
+    elif is_ready_to_infer(available_features=available_features, needed_features = ["YearBuilt"], inferred_feature= "RoofCover"):
+        
+        # Roof cover
+        if BIM['YearBuilt'] >= 1975:
+            roof_cover = 'spm'
         else:
-            MRDA = 'sup'  # superior
-    else:
-        MRDA = 'std'  # standard
+            # year < 1975
+            roof_cover = 'bur'
 
+    if "WindDebrisClass" in BIM:
+        WIDD = BIM["WindDebrisClass"]
+    else:
+        # Wind debris
+        WIDD = 'A'
+
+    if "Shutters" in BIM:
+        shutters = BIM["Shutters"]
+
+    elif is_ready_to_infer(available_features=available_features, needed_features = ["WindBorneDebris"], inferred_feature= "Shutters"):
+        # Shutters
+        shutters = BIM['WindBorneDebris']
+
+    if "RoofDeckAttachmentM" in BIM:
+        MRDA = BIM["RoofDeckAttachmentM"]
+
+    elif is_ready_to_infer(available_features=available_features, needed_features = ["YearBuilt","DesignWindSpeed"], inferred_feature= "RoofDeckAttachmentM"):
+        # Metal-RDA
+        if BIM['YearBuilt'] > 2000:
+            if BIM['DesignWindSpeed'] <= 142:
+                MRDA = 'std'  # standard
+            else:
+                MRDA = 'sup'  # superior
+        else:
+            MRDA = 'std'  # standard
+
+    is_ready_to_infer(available_features=available_features, needed_features = ["NumberOfStories"], inferred_feature= "Building Tag HUEF.H Class")
     if BIM['NumberOfStories'] <=2:
         bldg_tag = 'HUEF.H.S'
     elif BIM['NumberOfStories'] <= 5:
         bldg_tag = 'HUEF.H.M'
     else:
         bldg_tag = 'HUEF.H.L'
-
-
 
     essential_features = dict(
         BuildingTag = bldg_tag, 
@@ -274,44 +324,64 @@ def HUEFS_config(BIM):
         class.
     """
 
-    year = BIM['YearBuilt']  # just for the sake of brevity
+    if "RoofCover" in BIM:
+        roof_cover = BIM["RoofCover"]
 
-    # Roof cover
-    if year >= 1975:
-        roof_cover = 'spm'
-    else:
-        # year < 1975
-        roof_cover = 'bur'
-
-    # Wind debris
-    WIDD = 'C'
-
-    # Shutters
-    if year > 2000:
-        shutters = BIM['WindBorneDebris']
-    else:
-        # year <= 2000
-        if BIM['WindBorneDebris']:
-            shutters = random.random() < 0.46
+    elif is_ready_to_infer(available_features=available_features, needed_features = ["YearBuilt"], inferred_feature= "RoofCover"):
+        # Roof cover
+        if BIM['YearBuilt'] >= 1975:
+            roof_cover = 'spm'
         else:
-            shutters = False
+            # year < 1975
+            roof_cover = 'bur'
 
-    # Metal-RDA
-    if year > 2000:
-        if BIM['DesignWindSpeed'] <= 142:
+
+    if "WindDebrisClass" in BIM:
+        WIDD = BIM["WindDebrisClass"]
+
+    else:
+        # Wind debris
+        WIDD = 'C'
+
+
+    if "Shutters" in BIM:
+        shutters = BIM["Shutters"]
+        
+    elif is_ready_to_infer(available_features=available_features, needed_features = ["YearBuilt","WindBorneDebris"], inferred_feature= "Shutters"):
+        # Shutters
+        if BIM['YearBuilt'] > 2000:
+            shutters = BIM['WindBorneDebris']
+        else:
+            # year <= 2000
+            if BIM['WindBorneDebris']:
+                shutters = random.random() < 0.46
+            else:
+                shutters = False
+
+
+    if "RoofDeckAttachmentM" in BIM:
+        MRDA = BIM["RoofDeckAttachmentM"]
+        
+    elif is_ready_to_infer(available_features=available_features, needed_features = ["YearBuilt","DesignWindSpeed"], inferred_feature= "RoofDeckAttachmentM"):
+        # Metal-RDA
+        if BIM['YearBuilt'] > 2000:
+            if BIM['DesignWindSpeed'] <= 142:
+                MRDA = 'std'  # standard
+            else:
+                MRDA = 'sup'  # superior
+        else:
             MRDA = 'std'  # standard
-        else:
-            MRDA = 'sup'  # superior
-    else:
-        MRDA = 'std'  # standard
 
+
+    is_ready_to_infer(available_features=available_features, needed_features = ["NumberOfStories"], inferred_feature= "Building Tag HUEF.S")
     if BIM['NumberOfStories'] <=2:
         bldg_tag = 'HUEF.S.M'
     else:
         bldg_tag = 'HUEF.S.L'
 
-    # extend the BIM dictionary
 
+    # extend the BIM dictionary
+    
     essential_features = dict(
         BuildingTag = bldg_tag, 
         TerrainRoughness=int(BIM['TerrainRoughness']),

--- a/brails/inferers/hazus_hurricane_inferer/WindEFRulesets.py
+++ b/brails/inferers/hazus_hurricane_inferer/WindEFRulesets.py
@@ -62,6 +62,7 @@ def HUEFFS_config(BIM):
         A string that identifies a specific configration within this buidling
         class.
     """
+    available_features = BIM.keys()
 
     if "RoofCover" in BIM:
         roof_cover = BIM["RoofCover"]

--- a/brails/inferers/hazus_hurricane_inferer/hazus_hurricane_inferer.py
+++ b/brails/inferers/hazus_hurricane_inferer/hazus_hurricane_inferer.py
@@ -79,7 +79,6 @@ class HazusHurricaneInferer(InferenceEngine):
         seed=1,
         overwirte_existing=True,
         clean_features=False,
-
         planArea_key = "PlanArea",
         numberOfStories_key = "NumberOfStories",
         occupancyClass_key = "OccupancyClass",


### PR DESCRIPTION
Now the Brails Hurricane inferer will check the keys and give error messages like below. Please note that the checks for different archetypes are still being implemented at this moment so it will not yet capture all cases (and there may be more errors). But hopefully it will capture a good amount of it.

![image](https://github.com/user-attachments/assets/b02eae53-68ab-4641-9277-2597cf836cf2)

It does not yet check the value of the features (e.g. 'W1' provided while 'Wood' is being asked). This will require a different data schema validation approach and is something that needs to be further discussed
