### PR TITLE
Extending inference beyond 200 stories

### DIFF
--- a/brails/inferers/hazus_inferer/hazus_rulesets.py
+++ b/brails/inferers/hazus_inferer/hazus_rulesets.py
@@ -1463,7 +1463,7 @@ def get_hazus_height_classes_RES1():
     res1_height_classes = {
         "One-story": [1],
         "Two-story": [2],
-        "Three-story": list(range(3, 200)),  # TODO-ADAM: double check
+        "Three-story": list(range(3, 1000)),  # TODO-ADAM: double check
     }
 
     return res1_height_classes


### PR DESCRIPTION
When running the Bay Area testbed, a RES1 building with 340 stories (from NSI) caused the replacement cost inference module to break. Since such a large number of stories is unrealistic, we will treat it as a three-story building when estimating the replacement cost.

<img src="https://github.com/user-attachments/assets/ff8fc75c-1ebb-4a81-b1a5-8563ae42bbb5" width="500" height="700">
