### PR TITLE
feat(aggregators): add PyncodaHousingUnitSummarizer

### DIFF
--- a/brails/aggregators/__init__.py
+++ b/brails/aggregators/__init__.py
@@ -32,5 +32,8 @@
 # You should have received a copy of the BSD 3-Clause License along with
 # BRAILS. If not, see <http://www.opensource.org/licenses/>.
 
-from .housing_units.pyncoda.pyncoda_housing_units import PyncodaHousingUnitAllocator
+from .housing_units.pyncoda.pyncoda_housing_units import (
+    PyncodaHousingUnitAllocator,
+    PyncodaHousingUnitSummarizer,
+)
 from .points_to_polygons.basic.basic_points_to_polygons import BasicPointsToPolygonsAllocator

--- a/examples/housing_units/housing_unit_example.ipynb
+++ b/examples/housing_units/housing_unit_example.ipynb
@@ -321,7 +321,30 @@
    "metadata": {},
    "cell_type": "markdown",
    "source": [
-    "## 7. Export Results\n",
+    "## 7. Summarize Household Data\n",
+    "\n",
+    "Aggregate household stats (Population, Income, etc.) back to the building assets.\n",
+    "This flattens the detailed data into scalar building attributes to facilitate visualization."
+   ],
+   "id": "1bf32e20589fec5"
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "source": [
+    "from brails.aggregators import PyncodaHousingUnitSummarizer\n",
+    "\n",
+    "PyncodaHousingUnitSummarizer(bldg_inventory_imputed).summarize()"
+   ],
+   "id": "57af32ee51209cd4",
+   "outputs": [],
+   "execution_count": null
+  },
+  {
+   "metadata": {},
+   "cell_type": "markdown",
+   "source": [
+    "## 8. Export Results\n",
     "\n",
     "Finally, we save our work to local files:\n",
     "- **`bldg_inventory.geojson`**: The physical building inventory. Buildings with\n",

--- a/examples/housing_units/housing_unit_example.py
+++ b/examples/housing_units/housing_unit_example.py
@@ -237,7 +237,22 @@ def main(location: str):
     ).allocate()
 
     """
-    ## 7. Export Results
+    ## 7. Summarize Household Data
+    Aggregate household stats (Population, Income, etc.) back to the building assets.
+    This flattens the detailed data into scalar building attributes to facilitate visualization.
+    """
+    from brails.aggregators import PyncodaHousingUnitSummarizer
+    
+    PyncodaHousingUnitSummarizer(bldg_inventory_imputed).summarize()
+    
+    # Verify: print Population for a sample asset (if exists)
+    sample_id = bldg_inventory_imputed.get_asset_ids()[0]
+    sample_feat = bldg_inventory_imputed.get_asset_features(sample_id)[1]
+    if 'Population' in sample_feat:
+        print(f"Sample Building {sample_id} Population: {sample_feat['Population']}")
+
+    """
+    ## 8. Export Results
 
     Finally, we save our work to local files:
     - **`bldg_inventory.geojson`**: The physical building inventory. Buildings with


### PR DESCRIPTION
Introduces `PyncodaHousingUnitSummarizer` to aggregate detailed household-level data (generated by pyncoda) into building-level attributes. This flattening of data facilitates GIS visualization and downstream analysis that relies on building features.

Details:
- Implements counting logic for Population, Vacancy, and Tenure.
- Implements demographic aggregation (Income, Race, social characteristics) with specific handling for mixed attributes (e.g., "Two or More Races") and exclusion of vacant units from statistical calculations.
- Uses "N/A" for missing data to ensure JSON serialization compatibility.
- Updates the pyncoda example workflow to include this summarization step.
- Extends test suite with unit tests for edge cases (empty buildings, group quarters) and integration tests.