### PR TITLE
GeoJSON 3D-position fix + pyncoda user unit-counts and lean runs

### DIFF
--- a/brails/__init__.py
+++ b/brails/__init__.py
@@ -44,7 +44,7 @@
 from .utils.importer import Importer
 # Package metadata:
 name = 'brails'
-__version__ = '4.2.0'
+__version__ = '4.3.0'
 __copyright__ = (
     'Copyright (c) 2024, The Regents of the University of California'
 )

--- a/brails/aggregators/housing_units/pyncoda/pyncoda_housing_units.py
+++ b/brails/aggregators/housing_units/pyncoda/pyncoda_housing_units.py
@@ -414,6 +414,23 @@ class PyncodaHousingUnitAllocator:
             buildings_gdf[plan_area_col] * buildings_gdf[story_count_col]
         )
 
+        # Optionally carry a user-provided per-building housing unit count.
+        # When 'unit_count_col' is supplied in key_features, pyncoda uses these
+        # values directly instead of inferring unit counts from occupancy type.
+        # The fixed internal column name 'residential_units' is what we set as
+        # pyncoda's residential_unit_var in allocate().
+        unit_count_col = key_features.get('unit_count_col')
+        if unit_count_col:
+            if unit_count_col not in buildings_gdf.columns:
+                raise ValueError(
+                    f"unit_count_col '{unit_count_col}' was requested but is "
+                    'not a feature in the inventory. Available columns: '
+                    f'{sorted(buildings_gdf.columns)}'
+                )
+            lean_buildings_gdf['residential_units'] = pd.to_numeric(
+                buildings_gdf[unit_count_col], errors='coerce'
+            )
+
         return lean_buildings_gdf.set_index('building_id')
 
     def _validate_pyncoda_output(self, output_df: pd.DataFrame) -> None:
@@ -648,6 +665,15 @@ class PyncodaHousingUnitAllocator:
                 }
             }
 
+            # If the user supplied a per-building unit count, tell pyncoda to
+            # use it directly (via residential_unit_var) instead of inferring
+            # unit counts from occupancy type. The column name must match the
+            # one written in _prepare_inventory().
+            if self.key_features.get('unit_count_col'):
+                community_info['BRAILS Community']['building_inventory'][
+                    'residential_unit_var'
+                ] = 'residential_units'
+
             workflow = process_community_workflow(
                 community_info,
                 seed=self.seed,
@@ -660,6 +686,10 @@ class PyncodaHousingUnitAllocator:
                     output_dir / 'housing_unit_inventory_filtered.csv'
                 ),
                 force_hua_rerun=True,
+                # BRAILS only needs the raw building-household assignment, so
+                # skip pyncoda's IN-CORE figure and PDF codebook generation.
+                generate_figures=False,
+                generate_codebook=False,
             )
             assigned_housing_units = workflow.process_communities()
         except (OSError, ValueError, TypeError, KeyError, FileNotFoundError) as e:

--- a/brails/utils/geo_tools.py
+++ b/brails/utils/geo_tools.py
@@ -790,21 +790,27 @@ class GeoTools:
        
         gtype = geometry['type']
         coords = geometry['coordinates']
-       
+
+        # Drop altitude/extra dimensions; downstream BRAILS geometry is 2D.
         if gtype == 'Point':
-            return [coords]
-       
-        elif gtype in ['LineString', 'MultiLineString']:
-            return coords
-              
+            return [coords[:2]]
+
+        elif gtype == 'LineString':
+            return [p[:2] for p in coords]
+
+        elif gtype == 'MultiLineString':
+            return [[p[:2] for p in line] for line in coords]
+
         elif gtype == 'Polygon':
             # Exterior ring only
-            return coords[0]
-       
+            return [p[:2] for p in coords[0]]
+
         elif gtype == 'MultiPolygon':
             # Flatten all exterior rings:
-            multipolygons = [poly[0] for poly in coords if poly]
-            
+            multipolygons = [
+                [p[:2] for p in poly[0]] for poly in coords if poly
+            ]
+
             # Return a single polygon if only one exists, otherwise return the
             # full list:
             return multipolygons[0] if len(multipolygons) == 1 else multipolygons

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     "scikit-learn",
     "seaborn",
     "shapely",
-    "simcenter-pyncoda-fork==3.0.0.post1",
+    "simcenter-pyncoda-fork==3.0.0.post2",
     "supervision",
     "numpy",
     "timm",


### PR DESCRIPTION
This PR bundles two independent changes

### fix(geo_tools): strip Z from GeoJSON positions
GeoJSON (RFC 7946) permits positions with 3+ elements (e.g.
`[lon, lat, altitude]`), but `InputValidator.validate_coordinates` and the
downstream geometry pipeline assume strict 2-element pairs. With a 3D GeoJSON,
every `Asset` fails validation in `Asset.__init__`, silently falls back to an
empty coordinate list, and floods the log with "Coordinates input is not a
list" warnings — losing all geometry.

`parse_geojson_geometry` now slices each position to `[:2]` across the Point,
LineString, MultiLineString, Polygon, and MultiPolygon branches, dropping
altitude/extra dimensions before they reach the 2D-only validator. The combined
LineString/MultiLineString branch is split since their nesting depths differ.

*Follow-up worth considering:* making the geometry pipeline natively 3D-aware so
imported GeoJSON can round-trip without dropping altitude.

### feat(pyncoda): user-supplied unit counts + lean BRAILS runs
- **User-provided unit counts:** new optional `unit_count_col` key feature. When
  supplied, pyncoda uses the per-building housing-unit counts directly (via
  `residential_unit_var`) instead of inferring them from occupancy type. Raises
  a clear `ValueError` if the requested column isn't in the inventory.
- **Skip figure/codebook generation:** pass `generate_figures=False` and
  `generate_codebook=False` to `process_community_workflow`, so BRAILS skips
  pyncoda's IN-CORE figure and PDF codebook output it doesn't need.